### PR TITLE
set TG_NON_INTERACTIVE env in tg workflows

### DIFF
--- a/.github/workflows/tg-apply.yaml
+++ b/.github/workflows/tg-apply.yaml
@@ -56,6 +56,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.github_token }}
       TG_PROVIDER_CACHE: 1
       TG_PROVIDER_CACHE_DIR: "/tmp/.terragrunt-cache"
+      TERRAGRUNT_NON_INTERACTIVE: true # for backward compatibility
+      TG_NON_INTERACTIVE: true
     environment: ${{ inputs.github_environment }}
     steps:
       - name: "Checkout"

--- a/.github/workflows/tg-plan.yaml
+++ b/.github/workflows/tg-plan.yaml
@@ -66,6 +66,8 @@ jobs:
       - checks
     env:
       GITHUB_TOKEN: ${{ secrets.github_token }}
+      TERRAGRUNT_NON_INTERACTIVE: true # for backward compatibility
+      TG_NON_INTERACTIVE: true
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
PR to set the TG_NON_INTERACTIVE env variable in tg plan/apply workflows.

Error: https://github.com/yashrajdighe/iac/actions/runs/20004024095/job/59091357111?pr=57#step:6:577
Reference: https://terragrunt.gruntwork.io/docs/migrate/cli-redesign/#update-environment-variables